### PR TITLE
upgrade sys_version to 4

### DIFF
--- a/pkg/maker/cat/create.go
+++ b/pkg/maker/cat/create.go
@@ -59,6 +59,11 @@ func HandleCreate(
 			Tau:       3 * 60 * 60, // 3h
 		}
 
+		switch {
+		case r.SysVersion >= 4:
+			cat.Beg = number.Decimal("1.03")
+		}
+
 		prices, err := oracles.ListCurrent(ctx)
 		if err != nil {
 			log.WithError(err).Errorln("oracles.ListCurrent")

--- a/pkg/maker/cat/supply.go
+++ b/pkg/maker/cat/supply.go
@@ -20,7 +20,7 @@ func HandleSupply(collaterals core.CollateralStore) maker.HandlerFunc {
 			return err
 		}
 
-		if err := require(c.Live > 0, "not-live"); err != nil {
+		if err := require(r.SysVersion >= 4 || c.Live > 0, "not-live"); err != nil {
 			return maker.WithFlag(err, maker.FlagRefund)
 		}
 


### PR DESCRIPTION
1. cat.Supply() no longer need the collateral to be live
2. cat.Beg default to be 1.03